### PR TITLE
Freeze a README link to rstlint.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sphinx Lint
 
 Sphinx Lint is based on [rstlint.py from
-cpython](https://github.com/python/cpython/blob/main/Doc/tools/rstlint.py).
+cpython](https://github.com/python/cpython/blob/e0433c1e7/Doc/tools/rstlint.py).
 
 
 ## What sphinx-lint is, what it is not?


### PR DESCRIPTION
README.md links to rstlint.py in a dynamic head of `main` CPython branch:

```
    https://github.com/python/cpython/blob/main/Doc/tools/rstlint.py
                                           ^^^^
```

However, after https://github.com/python/cpython/pull/31097 is merged, the link will stop working. To keep it working, `main` needs to be replaced with some concrete commit SHA.