### PR TITLE
Add check for missing space after directive ::

### DIFF
--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -119,6 +119,10 @@ seems_directive_re = re.compile(r"(?<!\.)\.\. %s([^a-z:]|:(?!:))" % all_directiv
 # .. versionchanged:: 3.6
 three_dot_directive_re = re.compile(r"\.\.\. %s::" % all_directives)
 
+# Find directive missing space after double colon, like:
+# .. versionchanged::3.6
+missing_space_directive_re = re.compile(r"(?<!\.)\.\. %s::[^\s]" % simplename)
+
 # Find role used with double backticks instead of simple backticks like:
 # :const:``None``
 # instead of:
@@ -217,6 +221,8 @@ def check_suspicious_constructs(file, lines):
             yield lno, "comment seems to be intended as a directive"
         if three_dot_directive_re.search(line):
             yield lno, "directive should start with two dots, not three."
+        if missing_space_directive_re.search(line):
+            yield lno, "missing space after :: in directive"
         if double_backtick_role.search(line):
             yield lno, "role use a single backtick, double backtick found."
         if role_glued_with_word.search(line):

--- a/tests/fixtures/xfail/directive-missing-space.rst
+++ b/tests/fixtures/xfail/directive-missing-space.rst
@@ -1,0 +1,4 @@
+Missing space after ``::`` here:
+
+.. versionchanged::0.1
+   Foo bar baz.

--- a/tests/fixtures/xpass/directive-no-arguments.rst
+++ b/tests/fixtures/xpass/directive-no-arguments.rst
@@ -1,0 +1,3 @@
+Some directives can be invoked without arguments or content.
+
+.. contents::


### PR DESCRIPTION
For example:

.. versionadded::0.1

This is taken as a comment, thus no warning from docutils/Sphinx.

This doesn't yield any false positives in CPython.

Closes #7

----- 

This is a first PR to get familiar with the script.