### PR TITLE
Fix CI: Use matrix so all Python versions actually tested

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ name: Tests
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,30 +5,20 @@ name: Tests
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build_ubuntu:
+  test:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
         with:
-          python-version: "3.7"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/
-          key: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: .github/workflows/tests.yml
       - name: setup
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,7 @@
 
 name: Tests
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_ubuntu:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
# Before

Right now the four Python versions 3.7-3.10 are being set up on the same job, but then only one (3.10) is being used for the test run:

![image](https://user-images.githubusercontent.com/1324225/162428297-ffa4b420-743f-449a-8140-b20f6feb9bd7.png)

# PR

This PR adds the Python versions to the matrix so they are each tested in an independent job.

![image](https://user-images.githubusercontent.com/1324225/162428981-5baad7a2-d01c-4b76-bb68-1f5d7b8f6bfa.png)

Also:

* Add colour output for readability
* Use pip caching via `actions/setup-python` (also fixes the cache path for different OS)
* `fail-fast: false` means if, say, Windows fails, it allows the others continue. Easier to see what the problem is
* Allow testing feature branches, and add a button to be able to trigger build via the GitHub UI (like Travis CI has)
