### PR TITLE
Note PSF licence in PyPI metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 dist/
 __pycache__/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Sphinx Lint
 
 Sphinx Lint is based on [rstlint.py from
-cpython](https://github.com/python/cpython/blob/e0433c1e7/Doc/tools/rstlint.py).
+CPython](https://github.com/python/cpython/blob/e0433c1e7/Doc/tools/rstlint.py).
 
 
-## What sphinx-lint is, what it is not?
+## What is Sphinx Lint, what is it not?
 
 `sphinx-lint` should:
 
 - be reasonably fast so it's comfortable to use as a linter in your editor.
 - be usable on a single file.
-- not give any false positive (probably an utopy, but let's try).
-- not spend too much efforts finding errors that sphinx-build already find (or can easily find).
+- not give any false positives (probably a utopia, but let's try).
+- not spend too much effort finding errors that sphinx-build already finds (or can easily find).
 - focus on finding errors that are **not** visible to sphinx-build.
 
 
 ## Known issues
 
-Currently sphinx-lint can't work with tables, there's no understanding
-of how linesplit work in tables, like:
+Currently Sphinx Lint can't work with tables, there's no understanding
+of how `linesplit` works in tables, like:
 
 ```rst
    +-----------------------------------------+-----------------------------+---------------+
@@ -29,13 +29,13 @@ of how linesplit work in tables, like:
    +-----------------------------------------+-----------------------------+---------------+
 ```
 
-as sphinx-lint works line by line it will inevitably think the :meth: role is not closed properly.
+as Sphinx Lint works line by line it will inevitably think the `:meth:` role is not closed properly.
 
 To avoid false positives, some rules are skipped if we're in a table.
 
 
 ## License
 
-As this script was in the cpython repository the license is the PYTHON
-SOFTWARE FOUNDATION LICENSE VERSION 2, see LICENSE file for a full
+As this script was in the CPython repository the license is the Python
+Software Foundation Licence Version 2, see the LICENSE file for a full
 version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sphinx-lint"
 description = "Check for stylistic and formal issues in .rst and .py files included in the documentation."
 readme = "README.md"
-license = {text = "MIT License"}
+license = {text = "PSF License"}
 authors = [
     {name = "Georg Brandl", email = "georg@python.org"},
     {name = "Julien Palard", email = "julien@palard.fr"},

--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # Check for stylistic and formal issues in .rst and .py
 # files included in the documentation.
@@ -105,7 +104,7 @@ directives = [
 all_directives = "(" + "|".join(directives) + ")"
 before_role = r"(^|(?<=[\s(/'{\[*-]))"
 simplename = r"(?:(?!_)\w)+(?:[-._+:](?:(?!_)\w)+)*"
-role_head = r"({}:{}:)".format(before_role, simplename)  # A role, with a clean start
+role_head = fr"({before_role}:{simplename}:)"  # A role, with a clean start
 
 # Find comments that look like a directive, like:
 # .. versionchanged 3.6
@@ -127,8 +126,8 @@ three_dot_directive_re = re.compile(r"\.\.\. %s::" % all_directives)
 # :const:`None`
 double_backtick_role = re.compile(r"(?<!``)%s``" % role_head)
 
-start_string_prefix = "(^|(?<=\\s|[%s%s|]))" % (openers, delimiters)
-end_string_suffix = "($|(?=\\s|[\x00%s%s%s|]))" % (
+start_string_prefix = "(^|(?<=\\s|[{}{}|]))".format(openers, delimiters)
+end_string_suffix = "($|(?=\\s|[\x00{}{}{}|]))".format(
     closing_delimiters,
     delimiters,
     closers,
@@ -143,16 +142,16 @@ end_string_suffix = "($|(?=\\s|[\x00%s%s%s|]))" % (
 #     issue:`123`
 # instead of:
 #     :issue:`123`
-role_glued_with_word = re.compile(r"(^|\s)(?!:){}:`(?!`)".format(simplename))
+role_glued_with_word = re.compile(fr"(^|\s)(?!:){simplename}:`(?!`)")
 
 
 role_with_no_backticks = re.compile(
-    r"(^|\s):{}:(?![`:])[^\s`]+(\s|$)".format(simplename)
+    fr"(^|\s):{simplename}:(?![`:])[^\s`]+(\s|$)"
 )
 
 # Find role missing middle column, like:
 #    The :issue`123` is ...
-role_missing_right_column = re.compile(r"(^|\s):{}`(?!`)".format(simplename))
+role_missing_right_column = re.compile(fr"(^|\s):{simplename}`(?!`)")
 
 # Find role glued with a plural mark or something like:
 #    The :exc:`Exception`s
@@ -160,7 +159,7 @@ role_missing_right_column = re.compile(r"(^|\s):{}`(?!`)".format(simplename))
 #    The :exc:`Exceptions`\ s
 role_body = r"([^`]|\s`+|\\`)+"
 role_missing_surrogate_escape = re.compile(
-    r"{}`{}(?<![\\\s`])`(?!{})".format(role_head, role_body, end_string_suffix)
+    fr"{role_head}`{role_body}(?<![\\\s`])`(?!{end_string_suffix})"
 )
 
 # TODO: cover more cases
@@ -208,7 +207,7 @@ def is_in_a_table(error, line):
     return "|" in line[: error.start()] and "|" in line[error.end() :]
 
 
-backtick_in_front_of_role = re.compile(r"(^|\s)`:{}:`{}`".format(simplename, role_body))
+backtick_in_front_of_role = re.compile(fr"(^|\s)`:{simplename}:`{role_body}`")
 
 
 @checker(".rst", severity=2)
@@ -394,8 +393,7 @@ def check_bad_dedent_in_block(file, lines):
                 errors.append((block_lineno + lineno, "Bad dedent in block"))
 
     list(hide_non_rst_blocks(lines, hidden_block_cb=check_block))
-    for error in errors:
-        yield error
+    yield from errors
 
 
 def parse_args(argv=None):
@@ -501,14 +499,14 @@ def main(argv=None):
             print("Checking %s..." % file)
 
         try:
-            with open(file, "r", encoding="utf-8") as f:
+            with open(file, encoding="utf-8") as f:
                 text = f.read()
         except OSError as err:
-            print("%s: cannot open: %s" % (file, err))
+            print("{}: cannot open: {}".format(file, err))
             count[4] += 1
             continue
         except UnicodeDecodeError as err:
-            print("%s: cannot decode as UTF-8: %s" % (file, err))
+            print("{}: cannot decode as UTF-8: {}".format(file, err))
             count[4] += 1
             continue
 

--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -107,7 +107,7 @@ before_role = r"(^|(?<=[\s(/'{\[*-]))"
 simplename = r"(?:(?!_)\w)+(?:[-._+:](?:(?!_)\w)+)*"
 role_head = r"({}:{}:)".format(before_role, simplename)  # A role, with a clean start
 
-# Find comments that looks like a directive, like:
+# Find comments that look like a directive, like:
 # .. versionchanged 3.6
 # or
 # .. versionchanged: 3.6
@@ -412,7 +412,7 @@ def parse_args(argv=None):
         "-f",
         dest="false_pos",
         action="store_true",
-        help="enable checked that yield many false positives",
+        help="enable checkers that yield many false positives",
     )
     parser.add_argument(
         "-s",
@@ -425,7 +425,7 @@ def parse_args(argv=None):
         "-i",
         "--ignore",
         action="append",
-        help="ignore subdire or file path",
+        help="ignore subdir or file path",
         default=[],
     )
     parser.add_argument(
@@ -448,7 +448,7 @@ def is_disabled(msg, disabled_messages):
 def walk(path, ignore_list):
     """Wrapper around os.walk with an ignore list.
 
-    It also allow giving a file, thus yielding just that file.
+    It also allows giving a file, thus yielding just that file.
     """
     if isfile(path):
         yield path if path[:2] != "./" else path[2:]

--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -514,7 +514,7 @@ def main(argv=None):
     else:
         for severity in sorted(count):
             number = count[severity]
-            s = number > 1 and "s" or ""
+            s = "s" if number > 1 else ""
             print(f"{number} problem{s} with severity {severity} found.")
     sys.exit(int(bool(count)))
 


### PR DESCRIPTION
As mentioned in the `README` and classifiers, this project is using the PSF license, so let's update the metadata in `pyproject.toml` to match.

Also:

* Fix some typos and formatting
* Upgrade syntax for Python 3.7+
* More f-strings
* Ignore `build` dir from Git

Let me know if any of these should be split out.
