### PR TITLE
Detect missing backticks at end of roles.

### DIFF
--- a/tests/fixtures/xfail/missing-backtick-on-role.rst
+++ b/tests/fixtures/xfail/missing-backtick-on-role.rst
@@ -1,0 +1,4 @@
+In this paragraph there is a missing
+backtick at the end of a role,
+:class:`foo but no other issues,
+and there is other lines too.


### PR DESCRIPTION
Partially closes #19, I don't know if I can detect an unclosed-role followed by a default-role things like this...