### PR TITLE
Configure (and autodiscover) directives

### DIFF
--- a/directivegetter.py
+++ b/directivegetter.py
@@ -32,8 +32,8 @@ def write_directives(directives: Iterable[str]):
     lines = [
         "[lint]",
         "known_directives = [",
-        *tomlify_directives(DOCUTILS_DIRECTIVES, "reStructuredText"),
-        *tomlify_directives(SPHINX_DIRECTIVES, "Added by Sphinx"),
+        # *tomlify_directives(DOCUTILS_DIRECTIVES, "reStructuredText"),
+        # *tomlify_directives(SPHINX_DIRECTIVES, "Added by Sphinx"),
         *tomlify_directives(directives, "Added by extensions or in conf.py"),
         "]",
         "",  # final blank line

--- a/directivegetter.py
+++ b/directivegetter.py
@@ -62,12 +62,12 @@ def setup(app: Sphinx) -> dict[str, bool]:
     return {"parallel_read_safe": True, "parallel_write_safe": True}
 
 
-def collect_directives():
+def collect_directives(args=None):
     from sphinx import application
     from sphinx.application import Sphinx
 
     try:
-        source_dir, build_dir, *opts = sys.argv[1:]
+        source_dir, build_dir, *opts = args or sys.argv[1:]
     except ValueError:
         raise RuntimeError("Two arguments (source dir and build dir) are required.")
 

--- a/directivegetter.py
+++ b/directivegetter.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+
+from docutils.parsers.rst.directives import _directive_registry, _directives
+from docutils.parsers.rst.languages import en
+from sphinx.builders.dummy import DummyBuilder
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Iterable
+
+    from sphinx.application import Sphinx
+
+DOCUTILS_DIRECTIVES = frozenset(_directive_registry.keys() | en.directives.keys())
+SPHINX_DIRECTIVES = frozenset({
+    "acks", "centered", "codeauthor", "cssclass", "default-domain",
+    "deprecated", "describe", "highlight", "hlist", "index", "literalinclude",
+    "moduleauthor", "object", "only", "rst-class", "sectionauthor", "seealso",
+    "tabularcolumns", "toctree", "versionadded", "versionchanged",
+})
+CORE_DIRECTIVES = DOCUTILS_DIRECTIVES | SPHINX_DIRECTIVES
+
+
+def tomlify_directives(directives: Iterable[str], comment: str) -> Iterator[str]:
+    yield f"    # {comment}:"
+    yield from (f'    "{directive}",' for directive in sorted(directives))
+
+
+def write_directives(directives: Iterable[str]):
+    lines = [
+        "[lint]",
+        "known_directives = [",
+        *tomlify_directives(DOCUTILS_DIRECTIVES, "reStructuredText"),
+        *tomlify_directives(SPHINX_DIRECTIVES, "Added by Sphinx"),
+        *tomlify_directives(directives, "Added by extensions or in conf.py"),
+        "]",
+        "",  # final blank line
+    ]
+    with open("sphinx.toml", "w", encoding="utf-8") as file:
+        file.write("\n".join(lines))
+
+
+class DirectiveCollectorBuilder(DummyBuilder):
+    name = "directive_collector"
+
+    def get_outdated_docs(self) -> str:
+        return "nothing, just getting list of directives"
+
+    def read(self) -> list[str]:
+        write_directives({*_directives} - CORE_DIRECTIVES)
+        return []
+
+    def write(self, *args, **kwargs) -> None:
+        pass
+
+
+def setup(app: Sphinx) -> dict[str, bool]:
+    """Plugin for Sphinx"""
+    app.add_builder(DirectiveCollectorBuilder)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}
+
+
+def collect_directives():
+    from sphinx import application
+    from sphinx.application import Sphinx
+
+    try:
+        source_dir, build_dir, *opts = sys.argv[1:]
+    except ValueError:
+        raise RuntimeError("Two arguments (source dir and build dir) are required.")
+
+    application.builtin_extensions = (
+        *application.builtin_extensions,
+        "directivegetter"  # set up this file as an extension
+    )
+    app = Sphinx(
+        str(Path(source_dir)),
+        str(Path(source_dir)),
+        str(Path(build_dir)),
+        str(Path(build_dir, "doctrees")),
+        "directive_collector",
+    )
+    app.build(force_all=True)
+    raise SystemExit(app.statuscode)
+
+
+if __name__ == "__main__":
+    collect_directives()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 requires-python = ">= 3.7"
+dependencies = [
+    "tomli>=2; python_version < '3.11'",
+]
 dynamic = ["version"]
 
 [project.urls]

--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -76,28 +76,30 @@ openers = (
 
 # fmt: off
 directives = [
-    # standard docutils ones
-    'admonition', 'attention', 'caution', 'class', 'compound', 'container',
-    'contents', 'csv-table', 'danger', 'date', 'default-role', 'epigraph',
-    'error', 'figure', 'footer', 'header', 'highlights', 'hint', 'image',
-    'important', 'include', 'line-block', 'list-table', 'meta', 'note',
-    'parsed-literal', 'pull-quote', 'raw', 'replace',
-    'restructuredtext-test-directive', 'role', 'rubric', 'sectnum', 'sidebar',
-    'table', 'target-notes', 'tip', 'title', 'topic', 'unicode', 'warning',
-    # Sphinx and Python docs custom ones
-    'acks', 'attribute', 'autoattribute', 'autoclass', 'autodata',
-    'autoexception', 'autofunction', 'automethod', 'automodule',
-    'availability', 'centered', 'cfunction', 'class', 'classmethod', 'cmacro',
-    'cmdoption', 'cmember', 'code-block', 'confval', 'cssclass', 'ctype',
-    'currentmodule', 'cvar', 'data', 'decorator', 'decoratormethod',
-    'deprecated-removed', 'deprecated(?!-removed)', 'describe', 'directive',
-    'doctest', 'envvar', 'event', 'exception', 'function', 'glossary',
-    'highlight', 'highlightlang', 'impl-detail', 'index', 'literalinclude',
-    'method', 'miscnews', 'module', 'moduleauthor', 'opcode', 'pdbcommand',
-    'productionlist', 'program', 'role', 'sectionauthor', 'seealso',
-    'sourcecode', 'staticmethod', 'tabularcolumns', 'testcode', 'testoutput',
-    'testsetup', 'toctree', 'todo', 'todolist', 'versionadded',
-    'versionchanged'
+    # reStructuredText directives:
+    'admonition', 'attention', 'caution', 'class', 'code', 'code-block',
+    'compound', 'container', 'contents', 'csv-table', 'danger', 'date', 
+    'default-role', 'epigraph', 'error', 'figure', 'footer', 'header', 
+    'highlights', 'hint', 'image', 'important', 'include', 'line-block', 
+    'list-table', 'math', 'meta', 'note', 'parsed-literal', 'pull-quote', 'raw',
+    'replace', 'restructuredtext-test-directive', 'role', 'rubric', 
+    'section-numbering', 'sectnum', 'sidebar', 'sourcecode', 'table', 
+    'target-notes', 'tip', 'title', 'topic', 'unicode', 'warning',
+    # Added by Sphinx:
+    'acks', 'centered', 'codeauthor', 'default-domain', 'deprecated',
+    'describe', 'highlight', 'hlist', 'index', 'literalinclude', 'moduleauthor',
+    'object', 'only', 'rst-class', 'sectionauthor', 'seealso', 'tabularcolumns',
+    'toctree', 'versionadded', 'versionchanged',
+    # Python docs custom ones:
+    'attribute', 'autoattribute', 'autoclass', 'autodata', 'autoexception',
+    'autofunction', 'automethod', 'automodule', 'availability', 'cfunction',
+    'classmethod', 'cmacro', 'cmdoption', 'cmember', 'confval', 'cssclass',
+    'ctype', 'currentmodule', 'cvar', 'data', 'decorator', 'decoratormethod',
+    'deprecated-removed', 'deprecated(?!-removed)', 'directive', 'doctest',
+    'envvar', 'event', 'exception', 'function', 'glossary', 'highlightlang',
+    'impl-detail', 'method', 'miscnews', 'module', 'opcode', 'pdbcommand',
+    'productionlist', 'program', 'sourcecode', 'staticmethod', 'testcode',
+    'testoutput', 'testsetup', 'todo', 'todolist',
 ]
 # fmt: on
 

--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -21,8 +21,16 @@ import argparse
 from os.path import join, splitext, exists, isfile
 from collections import Counter
 from itertools import chain
+from typing import Any
 import multiprocessing
 
+if sys.version_info[:2] >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        tomllib = None
 
 # The following chars groups are from docutils:
 closing_delimiters = "\\\\.,;!?"
@@ -103,25 +111,9 @@ directives = [
 ]
 # fmt: on
 
-
-all_directives = "(" + "|".join(directives) + ")"
 before_role = r"(^|(?<=[\s(/'{\[*-]))"
 simplename = r"(?:(?!_)\w)+(?:[-._+:](?:(?!_)\w)+)*"
 role_head = rf"({before_role}:{simplename}:)"  # A role, with a clean start
-
-# Find comments that look like a directive, like:
-# .. versionchanged 3.6
-# or
-# .. versionchanged: 3.6
-# as it should be:
-# .. versionchanged:: 3.6
-seems_directive_re = re.compile(rf"^\s*(?<!\.)\.\. {all_directives}([^a-z:]|:(?!:))")
-
-# Find directive prefixed with three dots instead of two, like:
-# ... versionchanged:: 3.6
-# instead of:
-# .. versionchanged:: 3.6
-three_dot_directive_re = re.compile(rf"\.\.\. {all_directives}::")
 
 # Find role used with double backticks instead of simple backticks like:
 # :const:``None``
@@ -157,6 +149,10 @@ default_role_re = re.compile(r"(^| )`\w([^`]*?\w)?`($| )")
 seems_hyperlink_re = re.compile(r"`[^`]+?(\s?)<https?://[^`]+>`(_?)")
 
 leaked_markup_re = re.compile(r"[a-z]::\s|`|\.\.\s*\w+:")
+
+
+def get_all_directives() -> str:
+    return "(" + "|".join(directives) + ")"
 
 
 checkers = {}
@@ -244,6 +240,22 @@ def check_default_role(file, lines):
 @checker(".rst", severity=2)
 def check_directives(file, lines):
     """Check for mis-constructed directives."""
+    all_directives = get_all_directives()
+
+    # Find comments that look like a directive, like:
+    # .. versionchanged 3.6
+    # or
+    # .. versionchanged: 3.6
+    # as it should be:
+    # .. versionchanged:: 3.6
+    seems_directive_re = re.compile(rf"^\s*(?<!\.)\.\. {all_directives}([^a-z:]|:(?!:))")
+
+    # Find directive prefixed with three dots instead of two, like:
+    # ... versionchanged:: 3.6
+    # instead of:
+    # .. versionchanged:: 3.6
+    three_dot_directive_re = re.compile(rf"\.\.\. {all_directives}::")
+
     for lno, line in enumerate(lines, start=1):
         if seems_directive_re.search(line):
             yield lno, "comment seems to be intended as a directive"
@@ -386,7 +398,7 @@ def hide_non_rst_blocks(lines, hidden_block_cb=None):
 
 
 def type_of_explicit_markup(line):
-    if re.match(rf"\.\. {all_directives}::", line):
+    if re.match(rf"\.\. {get_all_directives()}::", line):
         return "directive"
     if re.match(r"\.\. \[[0-9]+\] ", line):
         return "footnote"
@@ -479,6 +491,22 @@ def parse_args(argv=None):
     return args
 
 
+def _read_toml(filename: str) -> dict[str, Any]:
+    if tomllib is None:
+        return {}
+    with open(filename, "rb") as f:
+        return tomllib.load(f)
+
+
+def get_config() -> dict[str, Any]:
+    if isfile("sphinx.toml"):
+        return _read_toml("sphinx.toml").get("lint", {})
+    if isfile("pyproject.toml"):
+        table = _read_toml("pyproject.toml")
+        return table.get("tool", {}).get("sphinx", {}).get("lint", {})
+    return {}
+
+
 def is_disabled(msg, disabled_messages):
     return any(disabled in msg for disabled in disabled_messages)
 
@@ -542,6 +570,10 @@ def check_file(filename, allow_false_positives=False, severity=1, disabled=()):
 
 def main(argv=None):
     args = parse_args(argv)
+    config = get_config()
+
+    # Append extra directives
+    directives.extend(config.get("known_directives", []))
 
     for path in args.paths:
         if not exists(path):

--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -451,6 +451,11 @@ def check_bad_dedent_in_block(file, lines):
 def parse_args(argv=None):
     if argv is None:
         argv = sys.argv
+    if argv[1:2] == ["init", "directives"]:
+        from directivegetter import collect_directives
+
+        raise SystemExit(collect_directives(sys.argv[2:]))
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "-v",


### PR DESCRIPTION
Closes #1, closes #25 (if implemented)

This is a proof of concept of configurable directive support and autodiscovery of directives.

Directive names can be listed in the `lint` table of `sphinx.toml` or from `tools.sphinx.lint` in `pyproject.toml`.

Auto discovery is currently in `directivegetter.py` -- this would probably need to be refactored into `sphinxlint/blah`.

I'd welcome thoughts or feedback!

A

