### PR TITLE
Fix a bug in the `paragraphs` function.

### DIFF
--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -244,11 +244,13 @@ def paragraphs(lines):
     paragraph_lno = 1
     for lno, line in enumerate(lines, start=1):
         if line != "\n":
+            if not paragraph:
+                # save the lno of the first line of the para
+                paragraph_lno = lno
             paragraph.append(line)
         elif paragraph:
             yield paragraph_lno, "".join(paragraph)
             paragraph = []
-            paragraph_lno = lno
     if paragraph:
         yield paragraph_lno, "".join(paragraph)
 

--- a/tests/fixtures/paragraphs.rst
+++ b/tests/fixtures/paragraphs.rst
@@ -1,0 +1,83 @@
+====================
+Paragraphs test file
+====================
+
+Introduction
+============
+
+This is a test rst used to check
+that the ``paragraphs`` function
+works properly and returns the correct
+line numbers.
+
+This issue was initially reported in
+https://github.com/sphinx-contrib/sphinx-lint/issues/32
+by Hugo.
+
+
+
+Bug
+===
+
+The function was bugged because
+it set the line number after one
+paragraph ended, instead of waiting
+for the beginning of the new one.
+
+
+This is why I'm putting several
+empty lines between paragraphs
+in this test file.
+
+
+I also wonder if the function should
+skip lines that contain only whitespace
+since they don't belong to the paragraph
+and the function might fail to parse
+files that use `\r\n` as newlines.
+
+
+
+
+Fix Description
+===============
+
+This fix:
+* adds this test file
+* adds a test for the
+  `paragraphs` function
+* adds a test to check
+  the lno in error msgs
+* fixes the code of the
+  `paragraphs` function
+
+
+
+lno check
+=========
+
+This section has a few markup errors,
+to ensure that the checkers now
+return the correct line number.
+
+
+
+This ``markup``will raise an error at line 65!
+
+
+This error is on the third line
+of this very long paragraph
+i.e. at :line:``70``!
+
+
+Note that the errors report the exact
+line, not the first line of the paragraph
+so for example an error like
+:foo`missing colon` will be reported
+at line 76 and not at line 73!
+
+
+.. note:
+   One of the tests in :file:`test_sphinxlint.py`
+   relies on exact line numbers, so if you edit
+   this section of the file you might break the test

--- a/tests/test_sphinxlint.py
+++ b/tests/test_sphinxlint.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import sphinxlint
+
 import pytest
 
 from sphinxlint import main
@@ -38,4 +40,28 @@ def test_sphinxlint_shall_not_pass(file, capsys):
     out, err = capsys.readouterr()
     assert out != "No problems found.\n"
     assert err == ""
+    assert error_count > 0
+
+
+@pytest.mark.parametrize("file", [str(FIXTURE_DIR / "paragraphs.rst")])
+def test_paragraphs(file):
+    with open(file) as f:
+        lines = f.readlines()
+    actual = sphinxlint.paragraphs(lines)
+    for lno, para in actual:
+        firstpline = para.splitlines(keepends=True)[0]
+        # check that the first line of the paragraph matches the
+        # corresponding line in the original file -- note that
+        # `lines` is 0-indexed but paragraphs return 1-indexed values
+        assert firstpline == lines[lno-1]
+
+
+@pytest.mark.parametrize("file", [str(FIXTURE_DIR / "paragraphs.rst")])
+def test_line_no_in_error_msg(file, capsys):
+    error_count = main(["sphinxlint.py", file])
+    out, err = capsys.readouterr()
+    assert err == ""
+    assert 'paragraphs.rst:76: role missing colon before' in out
+    assert 'paragraphs.rst:70: role use a single backtick' in out
+    assert 'paragraphs.rst:65: inline literal missing (escaped) space' in out
     assert error_count > 0


### PR DESCRIPTION
Fixes #32.

I was also wondering if the `if line != "\n":` check should be changed to `if line.strip()`, for two reasons:
* if the file uses `\r\n` newlines, the function won't work (unless newlines get normalized to `\n`)
* if the line contains only whitespace, it should probably still separate paragraphs