### PR TITLE
Fix ignoring files

### DIFF
--- a/sphinxlint.py
+++ b/sphinxlint.py
@@ -661,6 +661,8 @@ def walk(path, ignore_list):
     It also allows giving a file, thus yielding just that file.
     """
     if isfile(path):
+        if path in ignore_list:
+            return
         yield path if path[:2] != "./" else path[2:]
         return
     for root, dirs, files in os.walk(path):


### PR DESCRIPTION
# `main`

File isn't ignored:

```console
$ sphinx-lint *.rst --disable trailing-whitespace,missing-final-newline --ignore pep-0665.rst
pep-0665.rst:191: role use a single backtick, double backtick found. (role-with-double-backticks)
pep-0665.rst:199: role use a single backtick, double backtick found. (role-with-double-backticks)
```

# PR

Also consider the ignore list for files, not just paths:

```console
$ sphinx-lint *.rst --disable trailing-whitespace,missing-final-newline --ignore pep-0665.rst
No problems found.
```
