### PR TITLE
Run `sphinx-lint` against friend projects.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,9 @@ jobs:
         run: python -m pip install --upgrade pytest
       - name: Install sphinx-lint to pull dependencies
         run: python -m pip install -v .
-      - name: Download more tests from friend projects
-        run: sh download-more-tests.sh
-      - name: run tests
+      - name: Run tests
         run: python -m pytest
+      - name: Download more tests from friend projects
+        run: |
+          sh download-more-tests.sh
+          sphinx-lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Download more tests from friend projects
         run: |
           sh download-more-tests.sh
-          sphinx-lint
+          sphinx-lint tests/fixtures/friends/


### PR DESCRIPTION
I noticed that the workflow downloads "friend projects" but doesn't seem to run `sphinx-lint` against them -- only `pytest`.  However, it appears that none of those repos/dirs have any docs-related tests (or any tests at all), so nothing is done with that.

I'm assuming the intention was to run `sphinx-lint` against them, so I'm opening this draft PR to see what happens.