### PR TITLE
Add check for dangling hyphens

### DIFF
--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -447,3 +447,12 @@ def check_bad_dedent(file, lines, options=None):
 
     list(hide_non_rst_blocks(lines, hidden_block_cb=check_block))
     yield from errors
+
+
+@checker(".rst", rst_only=True)
+def check_dangling_hyphen(file, lines, options):
+    """Check for lines ending in a hyphen."""
+    for lno, line in enumerate(lines):
+        stripped_line = line.rstrip("\n")
+        if re.match(r".*[a-z]-$", stripped_line):
+            yield lno + 1, f"Line ends with dangling hyphen"

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -71,7 +71,7 @@ DIRECTIVES_CONTAINING_RST = [
     'cmdoption', 'cmember', 'confval', 'cssclass', 'ctype',
     'currentmodule', 'cvar', 'data', 'decorator', 'decoratormethod',
     'deprecated-removed', 'deprecated(?!-removed)', 'describe', 'directive',
-    'doctest', 'envvar', 'event', 'exception', 'function', 'glossary',
+    'envvar', 'event', 'exception', 'function', 'glossary',
     'highlight', 'highlightlang', 'impl-detail', 'index', 'literalinclude',
     'method', 'miscnews', 'module', 'moduleauthor', 'opcode', 'pdbcommand',
     'program', 'role', 'sectionauthor', 'seealso',
@@ -86,7 +86,7 @@ DIRECTIVES_CONTAINING_ARBITRARY_CONTENT = [
     'restructuredtext-test-directive', 'role', 'rubric', 'sectnum', 'table',
     'target-notes', 'title', 'unicode',
     # Sphinx and Python docs custom ones
-    'productionlist', 'code-block',
+    'code-block', 'doctest', 'productionlist',
 ]
 
 # fmt: on

--- a/tests/fixtures/xfail/dangling-hyphen.rst
+++ b/tests/fixtures/xfail/dangling-hyphen.rst
@@ -1,0 +1,5 @@
+.. expect: Line ends with dangling hyphen (dangling-hyphen)
+
+Additionally, this PEP requires that the default class definition
+namespace be ordered (e.g. ``OrderedDict``) by default.  The long-
+lived class namespace (``__dict__``) will remain a ``dict``.

--- a/tests/fixtures/xpass/dangling-hyphen.rst
+++ b/tests/fixtures/xpass/dangling-hyphen.rst
@@ -1,3 +1,22 @@
 Additionally, this PEP requires that the default class definition
 namespace be ordered (e.g. ``OrderedDict``) by default.  The
 long-lived class namespace (``__dict__``) will remain a ``dict``.
+
+::
+
+    Traceback (most recent call last):
+        File "<pyshell#6>", line 1, in -toplevel-
+            d.pop()
+    IndexError: pop from an empty deque
+
+.. doctest::
+
+   >>> setcontext(ExtendedContext)
+   >>> Decimal(1) / Decimal(0)
+   Decimal('Infinity')
+   >>> getcontext().traps[DivisionByZero] = 1
+   >>> Decimal(1) / Decimal(0)
+   Traceback (most recent call last):
+     File "<pyshell#112>", line 1, in -toplevel-
+       Decimal(1) / Decimal(0)
+   DivisionByZero: x / 0

--- a/tests/fixtures/xpass/dangling-hyphen.rst
+++ b/tests/fixtures/xpass/dangling-hyphen.rst
@@ -1,0 +1,3 @@
+Additionally, this PEP requires that the default class definition
+namespace be ordered (e.g. ``OrderedDict``) by default.  The
+long-lived class namespace (``__dict__``) will remain a ``dict``.

--- a/tests/test_filter_out_literal.py
+++ b/tests/test_filter_out_literal.py
@@ -28,6 +28,11 @@ But even if already indented it should work, see the next example.
    Yet this line should not be dropped.
 
 This one neither.
+
+.. doctest::
+
+   >>> # This should be dropped
+   >>> setcontext(ExtendedContext)
 """
 
 
@@ -58,6 +63,11 @@ But even if already indented it should work, see the next example.
    Yet this line should not be dropped.
 
 This one neither.
+
+.. doctest::
+
+
+
 """
 
 

--- a/tests/test_xpass_friends.py
+++ b/tests/test_xpass_friends.py
@@ -16,7 +16,7 @@ FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
 
 @pytest.mark.parametrize(
     "file",
-    [str(f) for f in (FIXTURE_DIR / "friends").iterdir() if ".DS_Store" not in str(f)]
+    [str(f) for f in (FIXTURE_DIR / "friends").iterdir() if f.name != ".DS_Store"]
     if (FIXTURE_DIR / "friends").is_dir()
     else [],
 )

--- a/tests/test_xpass_friends.py
+++ b/tests/test_xpass_friends.py
@@ -1,6 +1,6 @@
 """This test needs `download-more-tests.sh`.
 
-This is usefull to avoid a sphinx-lint release to break many CIs.
+This is useful to avoid a sphinx-lint release to break many CIs.
 """
 
 from pathlib import Path
@@ -16,7 +16,7 @@ FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
 
 @pytest.mark.parametrize(
     "file",
-    [str(f) for f in (FIXTURE_DIR / "friends").iterdir()]
+    [str(f) for f in (FIXTURE_DIR / "friends").iterdir() if ".DS_Store" not in str(f)]
     if (FIXTURE_DIR / "friends").is_dir()
     else [],
 )


### PR DESCRIPTION
Fixes https://github.com/sphinx-contrib/sphinx-lint/issues/54.

The failures are caused by finding IRL trailing hyphens in friend projects: pandas, cpython, peps, sympy.

```
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/pandas/doc/source/ecosystem.rst:380: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/pandas/doc/source/user_guide/integer_na.rst:61: Line ends with dangling hyphen (dangling-hyphen)
```
```
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/collections.rst:641: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/decimal.rst:295: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/decimal.rst:327: Line ends with dangling hyphen (dangling-hyphen)
```
```
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/peps/pep-0560.rst:283: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/peps/pep-0554.rst:1274: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/peps/pep-0633.rst:119: Line ends with dangling hyphen (dangling-hyphen)
```
```
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/sympy/doc/src/contributing/docstring.rst:50: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/sympy/doc/src/contributing/docstring.rst:741: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/vector/coordsys.rst:119: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/vector/coordsys.rst:217: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/combinatorics/fp_groups.rst:7: Line ends with dangling hyphen (dangling-hyphen)
```

---

Some false positives in there, such as:

```
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/decimal.rst:295: Line ends with dangling hyphen (dangling-hyphen)
E         + /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/decimal.rst:327: Line ends with dangling hyphen (dangling-hyphen)
```

Both are inside `.. doctest::` blocks:

https://github.com/python/cpython/blob/a35fd38b57d3eb05074ca36f3d57e1993c44ddc9/Doc/library/decimal.rst?plain=1#L295
https://github.com/python/cpython/blob/a35fd38b57d3eb05074ca36f3d57e1993c44ddc9/Doc/library/decimal.rst?plain=1#L327

We're using `rst_only=True` in the check to skip things like code blocks, but we're detecting `doctest` blocks as non-code. So let's fix that too.


---

Also, on macOS, I get failures like this, due to the annoying habit of macOS to create `.DS_Store` files, so let's skip them:

```pytb
tests/test_xpass_friends.py:30:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pathlib.py:1058: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = PosixPath('/Users/huvankem/github/sphinx-lint/tests/fixtures/friends/.DS_Store/flags'), mode = 'r', buffering = -1, encoding = 'UTF-8'
errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
E       NotADirectoryError: [Errno 20] Not a directory: '/Users/huvankem/github/sphinx-lint/tests/fixtures/friends/.DS_Store/flags'

/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pathlib.py:1044: NotADirectoryError
```

---

That leaves:

```
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/sympy/doc/src/contributing/docstring.rst:50: Line ends with dangling hyphen (dangling-hyphen)
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/sympy/doc/src/contributing/docstring.rst:741: Line ends with dangling hyphen (dangling-hyphen)
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/combinatorics/fp_groups.rst:7: Line ends with dangling hyphen (dangling-hyphen)
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/vector/coordsys.rst:119: Line ends with dangling hyphen (dangling-hyphen)
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/vector/coordsys.rst:217: Line ends with dangling hyphen (dangling-hyphen)
```
```
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/peps/pep-0554.rst:1274: Line ends with dangling hyphen (dangling-hyphen)
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/peps/pep-0633.rst:119: Line ends with dangling hyphen (dangling-hyphen)
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/peps/pep-0560.rst:283: Line ends with dangling hyphen (dangling-hyphen)
```
```
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/pandas/doc/source/ecosystem.rst:380: Line ends with dangling hyphen (dangling-hyphen)
E         + /Users/huvankem/github/sphinx-lint/tests/fixtures/friends/pandas/doc/source/user_guide/integer_na.rst:61: Line ends with dangling hyphen (dangling-hyphen)
```

These are valid, except these use hyphens like colons:

https://github.com/sympy/sympy/blob/5d2556f1546b1fe64e175fa808f495a58c3ac998/doc/src/modules/vector/coordsys.rst?plain=1#L119

https://github.com/sympy/sympy/blob/5d2556f1546b1fe64e175fa808f495a58c3ac998/doc/src/modules/vector/coordsys.rst?plain=1#L217

---

How should we deal with the failing "friend" tests?
