### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  ![Monthly downloads](https://img.shields.io/pypi/dm/sphinx-lint)
  ![Supported Python Version](https://img.shields.io/pypi/pyversions/sphinx-lint.svg)
 ](https://pypi.org/project/sphinx-lint)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/sphinx-contrib/sphinx-lint/Tests/main)](https://github.com/sphinx-contrib/sphinx-lint/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sphinx-contrib/sphinx-lint/tests.yml?branch=main)](https://github.com/sphinx-contrib/sphinx-lint/actions)
 
 Sphinx Lint is based on [rstlint.py from
 CPython](https://github.com/python/cpython/blob/e0433c1e7/Doc/tools/rstlint.py).


### PR DESCRIPTION
https://github.com/badges/shields/issues/8671 says:

> You need to update your badge URL from
> 
> `https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests`
> to
> `https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main`

# Before

![image](https://user-images.githubusercontent.com/1324225/228851808-de1abdc2-3dec-491d-acd1-f1f643c12207.png)

# After

![image](https://user-images.githubusercontent.com/1324225/228851843-6fd3b673-c367-4898-9619-3b4fd3720dfa.png)
