### PR TITLE
Skip default role check for multiline roles in tables

### DIFF
--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -117,6 +117,10 @@ def check_default_role(file, lines, options=None):
         if match:
             before_match = line[: match.start()]
             after_match = line[match.end() :]
+            stripped_line = line.strip()
+            if (stripped_line.startswith("|") and stripped_line.endswith("|") and
+                stripped_line.count("|") >= 4 and "|" in match.group(0)):
+                return  # we don't handle tables yet.
             if re.search(rst.ROLE_TAG + "$", before_match):
                 # It's not a default role: it starts with a tag.
                 continue

--- a/tests/fixtures/xfail/default-role-in-tables.rst
+++ b/tests/fixtures/xfail/default-role-in-tables.rst
@@ -1,0 +1,7 @@
+.. expect: default role used (hint: for inline literals, use double backticks) (default-role)
+
+In the following table there are a couple of default roles that should fail:
+
++-----------------+-------------------------------+----------------------------+
+| `French`        | Julien Palard `@JulienPalard` | `GitHub <github_fr_>`_     |
++-----------------+-------------------------------+----------------------------+

--- a/tests/fixtures/xpass/multiline-links-in-table.rst
+++ b/tests/fixtures/xpass/multiline-links-in-table.rst
@@ -1,0 +1,6 @@
+Links and default roles that span multiple lines in tables should be ignored:
+
++-----------------+-------------------------------+----------------------------+
+| `French (fr)    | Julien Palard (`@JulienPalard | `GitHub <github_fr_>`_     |
+| <doc_fr_>`_     | on GitHub`)                   |                            |
++-----------------+-------------------------------+----------------------------+


### PR DESCRIPTION
This PR fixes an issue that came up in python/devguide#1119 (see [`sphinx-lint` log](https://github.com/python/devguide/actions/runs/5266417049/jobs/9520312827?pr=1119)): when a link or a default role spans multiple lines in a table, it might get incorrectly reported, even if it's valid.

Several checkers already have a similar condition to ignore tables, however adding the same condition has a few limitations:
1. it only works for tables that have more than 3 columns
2. it might end up ignoring invalid markup on a single line within the same cell

Because of this, I made the check a bit more sophisticated, decreased the limit from >3 to >2 columns, added a test for the failure seen in the PR linked above, and an additional test to verify that invalid markup on a single line within the same cell is still detected.  The other checkers should probably be updated too, possibly factoring out the condition.