### PR TITLE
Allow users to provide an explicit process count

### DIFF
--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -58,6 +58,14 @@ def parse_args(argv=None):
                     ) from None
             setattr(namespace, self.dest, sort_fields)
 
+    class StoreNumJobsAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, StoreNumJobsAction._job_count(values))
+        def _job_count(values):
+            if values == "auto":
+                return os.cpu_count()
+            return max(int(values), 1)
+
     parser.add_argument(
         "-v",
         "--verbose",
@@ -108,6 +116,16 @@ def parse_args(argv=None):
         action=StoreSortFieldAction,
         help="comma-separated list of fields used to sort errors by. Available "
         f"fields are: {SortField.as_supported_options()}",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        metavar="N",
+        action=StoreNumJobsAction,
+        help="Run in parallle with N processes, defaults to \"auto\". "
+        "Special value \"auto\" will set N to cpu-count. "
+        "Values <= 1 are all considered 1.",
+        default=StoreNumJobsAction._job_count("auto")
     )
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"
@@ -209,10 +227,10 @@ def main(argv=None):
         for path in chain.from_iterable(walk(path, args.ignore) for path in args.paths)
     ]
 
-    if len(todo) < 8:
+    if args.jobs == 1 or len(todo) < 8:
         count = print_errors(sort_errors(starmap(check_file, todo), args.sort_by))
     else:
-        with multiprocessing.Pool() as pool:
+        with multiprocessing.Pool(processes=args.jobs) as pool:
             count = print_errors(
                 sort_errors(pool.imap_unordered(_check_file, todo), args.sort_by)
             )

--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -127,7 +127,7 @@ def parse_args(argv=None):
         help="Run in parallle with N processes, defaults to 'auto', "
         "which sets N to the number of logical CPUs."
         "Values <= 1 are all considered 1.",
-        default=StoreNumJobsAction._job_count("auto")
+        default=StoreNumJobsAction.job_count("auto")
     )
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"

--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -122,8 +122,8 @@ def parse_args(argv=None):
         "--jobs",
         metavar="N",
         action=StoreNumJobsAction,
-        help="Run in parallle with N processes, defaults to \"auto\". "
-        "Special value \"auto\" will set N to cpu-count. "
+        help="Run in parallle with N processes, defaults to 'auto', "
+        "which sets N to the number of logical CPUs."
         "Values <= 1 are all considered 1.",
         default=StoreNumJobsAction._job_count("auto")
     )

--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -61,6 +61,8 @@ def parse_args(argv=None):
     class StoreNumJobsAction(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
             setattr(namespace, self.dest, self._job_count(values))
+
+        @staticmethod
         def _job_count(values):
             if values == "auto":
                 return os.cpu_count()

--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -124,7 +124,7 @@ def parse_args(argv=None):
         "--jobs",
         metavar="N",
         action=StoreNumJobsAction,
-        help="Run in parallle with N processes, defaults to 'auto', "
+        help="Run in parallel with N processes. Defaults to 'auto', "
         "which sets N to the number of logical CPUs."
         "Values <= 1 are all considered 1.",
         default=StoreNumJobsAction.job_count("auto")

--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -60,7 +60,7 @@ def parse_args(argv=None):
 
     class StoreNumJobsAction(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            setattr(namespace, self.dest, StoreNumJobsAction._job_count(values))
+            setattr(namespace, self.dest, self._job_count(values))
         def _job_count(values):
             if values == "auto":
                 return os.cpu_count()

--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -63,7 +63,7 @@ def parse_args(argv=None):
             setattr(namespace, self.dest, self._job_count(values))
 
         @staticmethod
-        def _job_count(values):
+        def job_count(values):
             if values == "auto":
                 return os.cpu_count()
             return max(int(values), 1)


### PR DESCRIPTION
Useful for pre-commit hooks, as read in the discussion in #76, but probably in other situations too.

Instead of always defaulting to using as many processes are CPUs (or no sub-processes if checking less than 8 files), a new -p/--processes flag allows users to customise how many sub-processes will be used to perform the checks. Defaults to the old behavior (i.e., os.cpu_count() processes), caps values on the lower end to 1 automatically, and prevents subprocess spawning if requiring only one process.