### PR TITLE
Add caches to hot functions in `utils.py` that are called from multiple locations

### DIFF
--- a/sphinxlint/sphinxlint.py
+++ b/sphinxlint/sphinxlint.py
@@ -36,7 +36,7 @@ def check_text(filename, text, checkers, options=None):
     errors = []
     ext = splitext(filename)[1]
     checkers = {checker for checker in checkers if ext in checker.suffixes}
-    lines = text.splitlines(keepends=True)
+    lines = tuple(text.splitlines(keepends=True))
     if any(checker.rst_only for checker in checkers):
         lines_with_rst_only = hide_non_rst_blocks(lines)
     for check in checkers:

--- a/sphinxlint/utils.py
+++ b/sphinxlint/utils.py
@@ -1,4 +1,6 @@
 """Just a bunch of utility functions for sphinxlint."""
+from functools import lru_cache
+
 import regex as re
 from polib import pofile
 
@@ -27,6 +29,7 @@ def _clean_heuristic(paragraph, regex):
         paragraph = paragraph[: candidate.start()] + paragraph[candidate.end() :]
 
 
+@lru_cache()
 def clean_paragraph(paragraph):
     """Removes all good constructs, so detectors can focus on bad ones.
 
@@ -42,6 +45,7 @@ def clean_paragraph(paragraph):
     return paragraph.replace("\x00", "\\")
 
 
+@lru_cache()
 def escape2null(text):
     r"""Return a string with escape-backslashes converted to nulls.
 
@@ -174,6 +178,7 @@ def hide_non_rst_blocks(lines, hidden_block_cb=None):
     return output
 
 
+@lru_cache()
 def type_of_explicit_markup(line):
     """Tell apart various explicit markup blocks."""
     line = line.lstrip()

--- a/sphinxlint/utils.py
+++ b/sphinxlint/utils.py
@@ -79,10 +79,12 @@ def escape2null(text):
         start = found + 2  # skip character after escape
 
 
+@lru_cache()
 def paragraphs(lines):
     """Yield (paragraph_line_no, paragraph_text) pairs describing
     paragraphs of the given lines.
     """
+    output = []
     paragraph = []
     paragraph_lno = 1
     for lno, line in enumerate(lines, start=1):
@@ -92,10 +94,11 @@ def paragraphs(lines):
                 paragraph_lno = lno
             paragraph.append(line)
         elif paragraph:
-            yield paragraph_lno, "".join(paragraph)
+            output.append((paragraph_lno, "".join(paragraph)))
             paragraph = []
     if paragraph:
-        yield paragraph_lno, "".join(paragraph)
+        output.append((paragraph_lno, "".join(paragraph)))
+    return tuple(output)
 
 
 def looks_like_glued(match):

--- a/tests/test_sphinxlint.py
+++ b/tests/test_sphinxlint.py
@@ -70,7 +70,7 @@ def test_sphinxlint_shall_not_pass(file, expected_errors, capsys):
 @pytest.mark.parametrize("file", [str(FIXTURE_DIR / "paragraphs.rst")])
 def test_paragraphs(file):
     with open(file) as f:
-        lines = f.readlines()
+        lines = tuple(f.readlines())
     actual = paragraphs(lines)
     for lno, para in actual:
         firstpline = para.splitlines(keepends=True)[0]


### PR DESCRIPTION
This gives around a ~~16%~~ 24% speedup when running sphinx-lint on 7 ~large `.rst` files in CPython.

<details>
<summary>Benchmark script, that needs to be run from a directory that has a clone of CPython in it</summary>

```py
import sys
from sphinxlint.__main__ import main


files = [f"cpython/Doc/library/{module}.rst" for module in ("os", "typing", "sqlite3", "stdtypes", "argparse", "enum")]
files.append("cpython/Doc/reference/datamodel.rst")
args = ["foo"] + files

def test():
    main(args)
```

</details>

If the benchmark script is saved as `benchmark.py`, run the benchmark script using `python -m timeit -s "from benchmark import test" "test()"`.