### PR TITLE
Add a cache to `rst.inline_markup_gen()`

### DIFF
--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -4,7 +4,7 @@ In this file:
 - All constants are ALL_CAPS
 - All compiled regexes are suffixed by _RE
 """
-from functools import cache
+from functools import lru_cache
 
 import regex as re
 
@@ -152,7 +152,7 @@ ASCII_ALLOWED_AFTER_INLINE_MARKUP = r"""-.,:;!?/'")\]}>"""
 UNICODE_ALLOWED_AFTER_INLINE_MARKUP = r"\p{Pe}\p{Pi}\p{Pf}\p{Pd}\p{Po}"
 
 
-@cache
+@lru_cache(maxsize=None)
 def inline_markup_gen(start_string, end_string, extra_allowed_before=""):
     """Generate a regex matching an inline markup.
 

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -4,6 +4,7 @@ In this file:
 - All constants are ALL_CAPS
 - All compiled regexes are suffixed by _RE
 """
+from functools import cache
 
 import regex as re
 
@@ -151,6 +152,7 @@ ASCII_ALLOWED_AFTER_INLINE_MARKUP = r"""-.,:;!?/'")\]}>"""
 UNICODE_ALLOWED_AFTER_INLINE_MARKUP = r"\p{Pe}\p{Pi}\p{Pf}\p{Pd}\p{Po}"
 
 
+@cache
 def inline_markup_gen(start_string, end_string, extra_allowed_before=""):
     """Generate a regex matching an inline markup.
 


### PR DESCRIPTION
Part of #76. This yields another 3% speedup for me locally, using either of the benchmarks I posted in #79