### PR TITLE
Update Python version used to test friend projects.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # when adding new versions, update the one used to test 
+        # friend projects below to the latest one
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
@@ -31,7 +33,7 @@ jobs:
       - name: Install sphinx-lint to pull dependencies
         run: python -m pip install -v .
       - name: Download more tests from friend projects
-        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
         run: sh download-more-tests.sh
       - name: run tests
         run: python -m pytest


### PR DESCRIPTION
This PR updates  the Python version used to test friend projects in the CI workflow.  I also added a comment to remind people to update it.  We could avoid the comment by using a variable, but I'm not sure how to do it and it might make the file more complicated.