### PR TITLE
Fix for suggestion applied blindly during review

### DIFF
--- a/sphinxlint/__main__.py
+++ b/sphinxlint/__main__.py
@@ -60,7 +60,7 @@ def parse_args(argv=None):
 
     class StoreNumJobsAction(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            setattr(namespace, self.dest, self._job_count(values))
+            setattr(namespace, self.dest, self.job_count(values))
 
         @staticmethod
         def job_count(values):


### PR DESCRIPTION
Sorry! Should have been more careful when applying those suggestions.

BTW, I noticed that all those commits were not squashed after all, so the git history is now filled with `Update sphinxlint/__main__.py` messages. I went ahead with using the GitHub UI to apply those suggestions because I was under the impression that the whole branch would get squashed anyway.