### PR TITLE
Add Python 3.13 to the testing matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # when adding new versions, update the one used to test 
         # friend projects below to the latest one
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install sphinx-lint to pull dependencies
         run: python -m pip install -v .
       - name: Download more tests from friend projects
-        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
         run: sh download-more-tests.sh
       - name: run tests
         run: python -m pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
         # friend projects below to the latest one
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          # TODO Add Windows when regex wheel available for 3.13
+          - {os: windows-latest, python-version: "3.13"}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This adds 3.13 to the testing matrix, and if `setup-python` has been updated already, it will run the tests with 3.13 alpha 1.