### PR TITLE
Add link to changelog on pyproject.toml/PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dynamic = ["version"]
 
 
 [project.urls]
-repository = "https://github.com/sphinx-contrib/sphinx-lint"
+Repository = "https://github.com/sphinx-contrib/sphinx-lint"
+Changelog = "https://github.com/sphinx-contrib/sphinx-lint/releases"
 
 [project.scripts]
 sphinx-lint = "sphinxlint.__main__:main"


### PR DESCRIPTION
The PyPI page doesn't contain a changelog. 
![image](https://github.com/sphinx-contrib/sphinx-lint/assets/25624924/32bd8e89-7189-4c6d-9d24-2b9b3c540f4b)

This PR adds a link to the changelog in `pyproject.toml` and also on the PyPI page.