### PR TITLE
Use `require_serial: true` as the default for our pre-commit hook, not `-j1`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,6 @@
   name: Sphinx Lint
   description: 'Searches for common problems in Sphinx-flavored reST files'
   types: [rst]
-  # Defer to pre-commit on the best way to delegate resources across available cores
-  args: [--jobs=1]
+  require_serial: true  # we use multiprocessing internally anyway
   entry: sphinx-lint
   language: python


### PR DESCRIPTION
Currently we have `[--jobs=1]` as the default args for our pre-commit hook. This is problematic, however, as repos that override `args` in their `.pre-commit-config.yaml` files ([such as CPython](https://github.com/python/cpython/blob/bad7a35055dbe9e6297110eb8c72eb8edfefd42d/.pre-commit-config.yaml#L30)) have to re-specify `-j1` in their `args`: the value they provide for `args` _overrides_ the default we give here rather than _extending_ it.

This PR proposes that we don't give a default value for `args`, and instead give a default value for the `require_serial` key. Testing locally, using `require_serial: true` _does_ seem to be _slightly_ slower than using `--jobs=1` for me. But the difference is barely perceptible, and I think this is a big usability improvement: it means we don't have to document that, if you're overriding `args` in your `.pre-commit.config.yaml` file, you'll need to make sure to add `--jobs=1` in your override.