### PR TITLE
Print error messages to stderr

### DIFF
--- a/sphinxlint/cli.py
+++ b/sphinxlint/cli.py
@@ -138,7 +138,7 @@ def parse_args(argv=None):
     try:
         enabled_checkers = {all_checkers[name] for name in enabled_checkers_names}
     except KeyError as err:
-        print(f"Unknown checker: {err.args[0]}.")
+        print(f"Unknown checker: {err.args[0]}.", file=sys.stderr)
         sys.exit(2)
     return enabled_checkers, args
 
@@ -195,7 +195,7 @@ def print_errors(errors):
     """Print errors (or a message if nothing is to be printed)."""
     qty = 0
     for error in errors:
-        print(error)
+        print(error, file=sys.stderr)
         qty += 1
     if qty == 0:
         print("No problems found.")
@@ -221,7 +221,7 @@ def main(argv=None):
 
     for path in args.paths:
         if not os.path.exists(path):
-            print(f"Error: path {path} does not exist")
+            print(f"Error: path {path} does not exist", file=sys.stderr)
             return 2
 
     todo = [

--- a/tests/test_sphinxlint.py
+++ b/tests/test_sphinxlint.py
@@ -29,8 +29,8 @@ def test_sphinxlint_shall_trigger_false_positive(file, capsys):
     assert not has_errors
     has_errors = main(["sphinxlint.py", "--enable", "all", str(file)])
     out, err = capsys.readouterr()
-    assert err == ""
     assert out != "No problems found.\n"
+    assert err != ""
     assert has_errors
 
 
@@ -54,17 +54,17 @@ def test_sphinxlint_shall_not_pass(file, expected_errors, capsys):
     has_errors = main(["sphinxlint.py", "--enable", "all", file])
     out, err = capsys.readouterr()
     assert out != "No problems found.\n"
-    assert err == ""
+    assert err != ""
     assert has_errors
     assert expected_errors, (
         "That's not OK not to tell which errors are expected, "
         """add one using a ".. expect: " line."""
     )
     for expected_error in expected_errors:
-        assert expected_error in out
+        assert expected_error in err
     number_of_expected_errors = len(expected_errors)
-    number_of_reported_errors = len(out.splitlines())
-    assert number_of_expected_errors == number_of_reported_errors, f"{number_of_reported_errors=}, {out=}"
+    number_of_reported_errors = len(err.splitlines())
+    assert number_of_expected_errors == number_of_reported_errors, f"{number_of_reported_errors=}, {err=}"
 
 
 @pytest.mark.parametrize("file", [str(FIXTURE_DIR / "paragraphs.rst")])
@@ -84,8 +84,8 @@ def test_paragraphs(file):
 def test_line_no_in_error_msg(file, capsys):
     has_errors = main(["sphinxlint.py", file])
     out, err = capsys.readouterr()
-    assert err == ""
-    assert "paragraphs.rst:76: role missing colon before" in out
-    assert "paragraphs.rst:70: role use a single backtick" in out
-    assert "paragraphs.rst:65: inline literal missing (escaped) space" in out
+    assert out == ""
+    assert "paragraphs.rst:76: role missing colon before" in err
+    assert "paragraphs.rst:70: role use a single backtick" in err
+    assert "paragraphs.rst:65: inline literal missing (escaped) space" in err
     assert has_errors


### PR DESCRIPTION
Example of result of this change:

```sh
# Here is a file with reST issues.
$ sphinx-lint bad.po
bad.po:27: role with no backticks: ' :ref:kept ' (role-without-backticks)
$ sphinx-lint bad.po > /dev/null
bad.po:27: role with no backticks: ' :ref:kept ' (role-without-backticks)

# Here is a file with no issue.
$ sphinx-lint good.po
No problems found.
$ sphinx-lint good.po > /dev/null
```

Fixes #101 