### PR TITLE
Clarify escaping-backslashes at end of inline markup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ reStructuredText point of view, one case use `docutils`'s `pseudoxml`
 writer, like:
 
 ```text
+$ docutils --writer=pseudoxml <(echo '``hello``')
+<document source="/dev/fd/63">
+    <paragraph>
+        <literal>
+            hello
+```
+
+Or against a whole file:
+
+```text
 $ docutils --writer=pseudoxml tests/fixtures/xpass/role-in-code-sample.rst
 <document source="tests/fixtures/xpass/role-in-code-sample.rst">
     <paragraph>

--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -190,11 +190,12 @@ def check_missing_space_after_role(file, lines, options=None):
     Bad:  :exc:`Exception`s.
     Good: :exc:`Exceptions`\ s
     """
-    for lno, line in enumerate(lines, start=1):
-        line = clean_paragraph(line)
-        role = _SUSPICIOUS_ROLE.search(line)
+    for paragraph_lno, paragraph in paragraphs(lines):
+        paragraph = clean_paragraph(paragraph)
+        role = _SUSPICIOUS_ROLE.search(paragraph)
         if role:
-            yield lno, f"role missing (escaped) space after role: {role.group(0)!r}"
+            error_offset = paragraph[: role.start()].count("\n")
+            yield paragraph_lno + error_offset, f"role missing (escaped) space after role: {role.group(0)!r}"
 
 
 @checker(".rst", ".po")

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -161,11 +161,14 @@ def inline_markup_gen(start_string, end_string, extra_allowed_before=""):
     """
     if extra_allowed_before:
         extra_allowed_before = "|" + extra_allowed_before
+    # Both, inline markup start-string and end-string must not be
+    # preceded by an unescaped backslash (except for the end-string of
+    # inline literals).
+    if not (start_string == "``" and end_string == "``"):
+        end_string = f"(?<!\x00){end_string}"
+    start_string = f"(?<!\x00){start_string}"
     return re.compile(
         rf"""
-    (?<!\x00) # Both inline markup start-string and end-string must not be preceded by
-              # an unescaped backslash
-
     (?<=             # Inline markup start-strings must:
         ^|           # start a text block
         \s|          # or be immediately preceded by whitespace,

--- a/tests/fixtures/xpass/ref-in-samp.rst
+++ b/tests/fixtures/xpass/ref-in-samp.rst
@@ -1,0 +1,2 @@
+:samp:`"Please refer to the :ref:\`{security-considerations}\`
+section."`

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -1,0 +1,28 @@
+from sphinxlint.utils import escape2null as e2n
+from sphinxlint.rst import inline_markup_gen
+
+
+def test_inline_literals_can_end_with_escaping_backslash():
+    """See https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html
+    paragraph: Inline markup recognition rules
+    """
+    inline_markup_re = inline_markup_gen("``", "``")
+    assert inline_markup_re.findall(e2n(r"``\``")) == [e2n(r"``\``")]
+    assert inline_markup_re.findall(e2n(r"``\\``")) == [e2n(r"``\\``")]
+    assert inline_markup_re.findall(e2n(r"``\\\``")) == [e2n(r"``\\\``")]
+    assert inline_markup_re.findall(e2n(r"``\\\\``")) == [e2n(r"``\\\\``")]
+
+
+def test_emphasis_cannot_end_with_escaping_backslash():
+    """See https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html
+    paragraph: Inline markup recognition rules
+    """
+    emphasis_re = inline_markup_gen(r"\*", r"\*")
+    assert emphasis_re.findall(e2n(r"*\*")) == []
+    assert emphasis_re.findall(e2n(r"*\\*")) == [e2n(r"*\\*")]
+    assert emphasis_re.findall(e2n(r"*\\\*")) == []
+    assert emphasis_re.findall(e2n(r"*\\\\*")) == [e2n(r"*\\\\*")]
+
+    assert emphasis_re.findall(
+        e2n(r"Tous les *\*args* et *\*\*kwargs* fournis à cette fonction sont")
+    ) == [e2n(r"*\*args*"), e2n(r"*\*\*kwargs*")]


### PR DESCRIPTION
Previously `Tous les *\*args* et *\*\*kwargs* fournis à cette fonction sont` was cleaned as `Tous les  et kwargs* fournis à cette fonction sont` because `*\*\*` at the beginning of `*\*\*kwargs*` was considered an emphasis.