### PR TITLE
Include C construct directives for RST checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 __pycache__/
 *.egg-info/
 .coverage
+.coverage.*
 .envrc
 .tox/
 .venv/

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -60,7 +60,10 @@ OPENERS = (
 # fmt: off
 DIRECTIVES_CONTAINING_RST = [
     # standard docutils ones
-    'admonition', 'attention', 'caution', 'class', 'compound', 'container',
+    'admonition', 'attention',
+    'c:data', 'c:enum', 'c:enumerator', 'c:func', 'c:macro', 'c:member',
+    'c:struct', 'c:type', 'c:union', 'c:var',
+    'caution', 'class', 'compound', 'container',
     'danger', 'epigraph', 'error', 'figure', 'footer', 'header', 'highlights',
     'hint', 'image', 'important', 'include', 'line-block', 'list-table', 'meta',
     'note', 'parsed-literal', 'pull-quote', 'replace', 'sidebar', 'tip', 'topic',

--- a/tests/fixtures/xfail/default-role-in-c-type.rst
+++ b/tests/fixtures/xfail/default-role-in-c-type.rst
@@ -1,0 +1,8 @@
+.. expect: default role used (hint: for inline literals, use double backticks) (default-role)
+
+.. c:type:: int (*PyCode_WatchCallback)(PyCodeEvent event, PyCodeObject* co)
+
+   If *event* is ``PY_CODE_EVENT_CREATE``, then the callback is invoked
+   after `co` has been fully initialized. Otherwise, the callback is invoked
+   before the destruction of *co* takes place, so the prior state of *co*
+   can be inspected.


### PR DESCRIPTION
Fixes https://github.com/sphinx-contrib/sphinx-lint/issues/108.

Add the "cross-referencing C constructs" from:

https://www.sphinx-doc.org/en/master/usage/domains/c.html#cross-referencing-c-constructs

The 3.13/Ubuntu job fails as expected, because it also checks the friend projects, and finds the two CPython examples mentioned in the issue:

```
sphinx-lint/tests/fixtures/friends/cpython/Doc/c-api/function.rst:171: default role used (hint: for inline literals, use double backticks) (default-role)
sphinx-lint/tests/fixtures/friends/cpython/Doc/c-api/code.rst:171: default role used (hint: for inline literals, use double backticks) (default-role)
```

Also Git ignore coverage data files (for example: `.coverage.Hugos-MacBook-Pro.local.95733.XMjioudx`).