### PR TITLE
lint: unify Black with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.2.2
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--exit-zero-on-fix"]
       - id: ruff-format
         args: ["--preview"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
       - id: ruff
         args: ["--exit-non-zero-on-fix"]
       - id: ruff-format
-        args: ["--preview"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
-    hooks:      - id: ruff-format
-        args: ["--preview"]
+    hooks:
       - id: ruff
         args: ["--fix"]
+      - id: ruff-format
+        args: ["--preview"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.2.2
     hooks:
       - id: ruff
-        args: ["--exit-zero-on-fix"]
+        args: ["--exit-non-zero-on-fix"]
       - id: ruff-format
         args: ["--preview"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,13 +21,13 @@ repos:
         exclude: tests/fixtures/xfail/trailing-whitespaces.rst
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.5.1
+    rev: 1.7.0
     hooks:
       - id: pyproject-fmt
         additional_dependencies: [tox]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.15
+    rev: v0.16
     hooks:
       - id: validate-pyproject
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
-    hooks:
+    rev: v0.2.2
+    hooks:      - id: ruff-format
+        args: ["--preview"]
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
-    hooks:
-      - id: black
+        args: ["--fix"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,6 @@ packages = ["sphinxlint"]
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 
-[tool.black]
-
 [tool.ruff]
 select = [
   "E", # pycodestyle errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,8 @@ extend-ignore = [
   "UP038", # makes code slower and more verbose
 ]
 
+[tool.ruff.format]
+preview = true
+
 [tool.pylint.variables]
 callbacks = ["check_"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,10 @@ packages = ["sphinxlint"]
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 
-[tool.ruff.lint]
+[tool.ruff]
 fix = true
+
+[tool.ruff.lint]
 select = [
   "E", # pycodestyle errors
   "F", # pyflakes errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,11 @@ packages = ["sphinxlint"]
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
   "E", # pycodestyle errors
   "F", # pyflakes errors
   "I", # isort
-  "ISC", # flake8-implicit-str-concat
   "PGH", # pygrep-hooks
   "RUF100", # unused noqa (yesqa)
   "UP", # pyupgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ packages = ["sphinxlint"]
 local_scheme = "no-local-version"
 
 [tool.ruff.lint]
+fix = true
 select = [
   "E", # pycodestyle errors
   "F", # pyflakes errors

--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -445,7 +445,7 @@ def check_line_too_long(file, lines, options=None):
                 continue  # ignore anonymous hyperlink targets
             if _is_very_long_string_literal(line):
                 continue  # ignore a very long literal string
-            yield lno + 1, f"Line too long ({len(line)-1}/{options.max_line_length})"
+            yield lno + 1, f"Line too long ({len(line) - 1}/{options.max_line_length})"
 
 
 @checker(".html", enabled=False, rst_only=False)

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -4,6 +4,7 @@ In this file:
 - All constants are ALL_CAPS
 - All compiled regexes are suffixed by _RE
 """
+
 from functools import lru_cache
 
 import regex as re

--- a/sphinxlint/utils.py
+++ b/sphinxlint/utils.py
@@ -1,4 +1,5 @@
 """Just a bunch of utility functions for sphinxlint."""
+
 from functools import lru_cache
 
 import regex as re


### PR DESCRIPTION
As Ruff [claims](https://pypi.org/project/ruff/0.0.47/#:~:text=ruff%20is%20compatible%20with%20Black,that%20are%20obviated%20by%20autoformatting.) full compatibility with Black, it makes sense just to use one tool for both to prevent eventual collisions; also bumping Ruff to the latest `0.2.2`

cc: @hugovk 