### PR TITLE
Add checker for searching unnecessary parentheses in func & meth role

### DIFF
--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -515,14 +515,16 @@ def check_dangling_hyphen(file, lines, options):
             yield lno + 1, "Line ends with dangling hyphen"
 
 
-@checker(".rst", ".po", rst_only=False)
+@checker(".rst", ".po", rst_only=False, enabled=False)
 def check_unnecessary_func_parentheses(filename, lines, options):
     """Check for unnecessary parentheses in :func: roles.
 
     Bad:  :func:`test()`
     Good: :func:`test`
+
+    TODO: The checker is disabled since some of the friend projects does not follow
+    this new rule. We should enable it once the issues are all resolved.
     """
     for lno, line in enumerate(lines, start=1):
-        match = rst.FUNC_ROLE_WITH_UNNECESSARY_PARENTHESES.search(line)
-        if match:
+        if match := rst.FUNC_ROLE_WITH_UNNECESSARY_PARENTHESES.search(line):
             yield lno, f"Unnecessary parentheses in {match.group(0).strip()!r}"

--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -516,8 +516,8 @@ def check_dangling_hyphen(file, lines, options):
 
 
 @checker(".rst", ".po", rst_only=False, enabled=False)
-def check_unnecessary_func_parentheses(filename, lines, options):
-    """Check for unnecessary parentheses in :func: roles.
+def check_unnecessary_parentheses(filename, lines, options):
+    """Check for unnecessary parentheses in :func: and :meth: roles.
 
     Bad:  :func:`test()`
     Good: :func:`test`
@@ -526,5 +526,5 @@ def check_unnecessary_func_parentheses(filename, lines, options):
     this new rule. We should enable it once the issues are all resolved.
     """
     for lno, line in enumerate(lines, start=1):
-        if match := rst.FUNC_ROLE_WITH_UNNECESSARY_PARENTHESES.search(line):
+        if match := rst.ROLE_WITH_UNNECESSARY_PARENTHESES_RE.search(line):
             yield lno, f"Unnecessary parentheses in {match.group(0).strip()!r}"

--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -515,15 +515,12 @@ def check_dangling_hyphen(file, lines, options):
             yield lno + 1, "Line ends with dangling hyphen"
 
 
-@checker(".rst", ".po", rst_only=False, enabled=False)
+@checker(".rst", ".po", rst_only=False, enabled=True)
 def check_unnecessary_parentheses(filename, lines, options):
     """Check for unnecessary parentheses in :func: and :meth: roles.
 
     Bad:  :func:`test()`
     Good: :func:`test`
-
-    TODO: The checker is disabled since some of the friend projects does not follow
-    this new rule. We should enable it once the issues are all resolved.
     """
     for lno, line in enumerate(lines, start=1):
         if match := rst.ROLE_WITH_UNNECESSARY_PARENTHESES_RE.search(line):

--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -513,3 +513,16 @@ def check_dangling_hyphen(file, lines, options):
         stripped_line = line.rstrip("\n")
         if _has_dangling_hyphen(stripped_line):
             yield lno + 1, "Line ends with dangling hyphen"
+
+
+@checker(".rst", ".po", rst_only=False)
+def check_unnecessary_func_parentheses(filename, lines, options):
+    """Check for unnecessary parentheses in :func: roles.
+
+    Bad:  :func:`test()`
+    Good: :func:`test`
+    """
+    for lno, line in enumerate(lines, start=1):
+        match = rst.FUNC_ROLE_WITH_UNNECESSARY_PARENTHESES.search(line)
+        if match:
+            yield lno, f"Unnecessary parentheses in {match.group(0).strip()!r}"

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -280,3 +280,5 @@ TRIPLE_BACKTICKS_RE = re.compile(
 )
 
 ROLE_MISSING_CLOSING_BACKTICK_RE = re.compile(rf"({ROLE_HEAD}`[^`]+?)[^`]*$")
+
+FUNC_ROLE_WITH_UNNECESSARY_PARENTHESES = re.compile(r"(^|\s):func:`[^`]+\(\)`")

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -281,4 +281,4 @@ TRIPLE_BACKTICKS_RE = re.compile(
 
 ROLE_MISSING_CLOSING_BACKTICK_RE = re.compile(rf"({ROLE_HEAD}`[^`]+?)[^`]*$")
 
-FUNC_ROLE_WITH_UNNECESSARY_PARENTHESES = re.compile(r"(^|\s):func:`[^`]+\(\)`")
+ROLE_WITH_UNNECESSARY_PARENTHESES_RE = re.compile(r"(^|\s):(func|meth):`[^`]+\(\)`")


### PR DESCRIPTION
resolve #114 

<details><summary>test summary</summary>

```

=========================== short test summary info ============================
FAILED tests/test_xpass_friends.py::test_sphinxlint_friend_projects_shall_pass[~/repos/sphinx-lint/tests/fixtures/friends/sympy] - assert ...
  + ~/repos/sphinx-lint/tests/fixtures/friends/sympy/doc/src/tutorials/intro-tutorial/matrices.rst:62: Unnecessary parentheses in ':func:`~.shape()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/plotting.rst:289: Unnecessary parentheses in ':func:`~.plot_implicit()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/holonomic/uses.rst:39: Unnecessary parentheses in ':func:`~HolonomicFunction.to_expr()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/sympy/doc/src/modules/holonomic/uses.rst:41: Unnecessary parentheses in ':func:`~HolonomicFunction.integrate()`' (unnecessary-func-parentheses)

FAILED tests/test_xpass_friends.py::test_sphinxlint_friend_projects_shall_pass[~/repos/sphinx-lint/tests/fixtures/friends/cpython] - assert ...
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/tutorial/floatingpoint.rst:233: Unnecessary parentheses in ':func:`math.fsum()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/asyncio-runner.rst:94: Unnecessary parentheses in ':func:`asyncio.run()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/using/ios.rst:56: Unnecessary parentheses in ':func:`platform.ios_ver()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/using/ios.rst:59: Unnecessary parentheses in ':func:`os.uname()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/token.rst:78: Unnecessary parentheses in ':func:`ast.parse()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/using/cmdline.rst:1034: Unnecessary parentheses in ':func:`sys._enablelegacywindowsfsencoding()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/time.rst:330: Unnecessary parentheses in ':func:`time.monotonic()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/time.rst:342: Unnecessary parentheses in ':func:`time.monotonic()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/unittest.rst:2532: Unnecessary parentheses in ':func:`unittest.main()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/functions.rst:164: Unnecessary parentheses in ':func:`pdb.set_trace()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/functions.rst:1339: Unnecessary parentheses in ':func:`locale.getencoding()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/platform.rst:153: Unnecessary parentheses in ':func:`os.uname()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/platform.rst:168: Unnecessary parentheses in ':func:`os.uname()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/sys.rst:738: Unnecessary parentheses in ':func:`_clear_internal_caches()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/sys.rst:742: Unnecessary parentheses in ':func:`getallocatedblocks()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/subprocess.rst:611: Unnecessary parentheses in ':func:`grp.getgrnam()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/subprocess.rst:621: Unnecessary parentheses in ':func:`grp.getgrnam()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/subprocess.rst:629: Unnecessary parentheses in ':func:`pwd.getpwnam()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/inspect.rst:1264: Unnecessary parentheses in ':func:`eval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/inspect.rst:1278: Unnecessary parentheses in ':func:`eval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/inspect.rst:1280: Unnecessary parentheses in ':func:`eval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/inspect.rst:1281: Unnecessary parentheses in ':func:`eval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/inspect.rst:1286: Unnecessary parentheses in ':func:`eval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/inspect.rst:1287: Unnecessary parentheses in ':func:`eval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/tarfile.rst:618: Unnecessary parentheses in ':func:`staticmethod()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/enum.rst:666: Unnecessary parentheses in ':func:`repr()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/signal.rst:428: Unnecessary parentheses in ':func:`threading.get_ident()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/io.rst:953: Unnecessary parentheses in ':func:`locale.getencoding()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/io.rst:1185: Unnecessary parentheses in ':func:`open()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/io.rst:1187: Unnecessary parentheses in ':func:`print()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/zipapp.rst:335: Unnecessary parentheses in ':func:`sys.getfilesystemencoding()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/contextvars.rst:18: Unnecessary parentheses in ':func:`threading.local()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/contextvars.rst:149: Unnecessary parentheses in ':func:`threading.local()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/sysconfig.rst:308: Unnecessary parentheses in ':func:`get_preferred_scheme()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/functools.rst:37: Unnecessary parentheses in ':func:`lru_cache()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/ipaddress.rst:1013: Unnecessary parentheses in ':func:`sorted()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/test.rst:1704: Unnecessary parentheses in ':func:`warnings.catch_warnings()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/getpass.rst:52: Unnecessary parentheses in ':func:`os.getlogin()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/stdtypes.rst:3480: Unnecessary parentheses in ':func:`str.swapcase()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/ast.rst:2137: Unnecessary parentheses in ':func:`compile()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/compileall.rst:93: Unnecessary parentheses in ':func:`os.process_cpu_count()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/pdb.rst:52: Unnecessary parentheses in ':func:`breakpoint()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.3.rst:782: Unnecessary parentheses in ':func:`unicodedata.lookup()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.3.rst:783: Unnecessary parentheses in ':func:`unicodedata.lookup()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.2.rst:2324: Unnecessary parentheses in ':func:`sys.setswitchinterval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.6.rst:514: Unnecessary parentheses in ':func:`sys.getfilesystemencoding()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.6.rst:517: Unnecessary parentheses in ':func:`os.fsencode()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.6.rst:783: Unnecessary parentheses in ':func:`os.urandom()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.6.rst:1319: Unnecessary parentheses in ':func:`pickletools.dis()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.14.rst:202: Unnecessary parentheses in ':func:`pdb.set_trace()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.7.rst:2369: Unnecessary parentheses in ':func:`re.sub()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.4.rst:1970: Unnecessary parentheses in ':func:`sys.getallocatedblocks()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/os.rst:116: Unnecessary parentheses in ':func:`sys.getfilesystemencoding()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/os.rst:117: Unnecessary parentheses in ':func:`locale.getpreferredencoding()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/os.rst:136: Unnecessary parentheses in ':func:`os.fsdecode()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/os.rst:137: Unnecessary parentheses in ':func:`open()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/os.rst:797: Unnecessary parentheses in ':func:`platform.uname()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/library/os.rst:2863: Unnecessary parentheses in ':func:`~scandir.close()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.9.rst:986: Unnecessary parentheses in ':func:`wave.open()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.12.rst:1425: Unnecessary parentheses in ':func:`hashlib.pbkdf2_hmac()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.12.rst:1427: Unnecessary parentheses in ':func:`~hashlib.pbkdf2_hmac()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:939: Unnecessary parentheses in ':func:`logging.basicConfig()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:1178: Unnecessary parentheses in ':func:`socket.if_nameindex()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:1179: Unnecessary parentheses in ':func:`socket.if_indextoname()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:1196: Unnecessary parentheses in ':func:`statistics.mean()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:1199: Unnecessary parentheses in ':func:`statistics.geometric_mean()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:1370: Unnecessary parentheses in ':func:`~unittest.addModuleCleanup()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:1372: Unnecessary parentheses in ':func:`~unittest.setUpModule()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.8.rst:1435: Unnecessary parentheses in ':func:`–xml.etree.ElementTree.canonicalize()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.10.rst:1236: Unnecessary parentheses in ':func:`itertools.pairwise()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.10.rst:1248: Unnecessary parentheses in ':func:`os.cpu_count()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.10.rst:1255: Unnecessary parentheses in ':func:`os.splice()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/whatsnew/3.10.rst:1295: Unnecessary parentheses in ':func:`platform.freedesktop_os_release()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/howto/instrumentation.rst:310: Unnecessary parentheses in ':func:`gc.collect()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/howto/enum.rst:12: Unnecessary parentheses in ':func:`repr()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/howto/enum.rst:170: Unnecessary parentheses in ':func:`auto()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/c-api/import.rst:193: Unnecessary parentheses in ':func:`!imp.source_from_cache()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/howto/descriptor.rst:516: Unnecessary parentheses in ':func:`super()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/deprecations/pending-removal-in-3.13.rst:51: Unnecessary parentheses in ':func:`importlib.resources.files()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/deprecations/pending-removal-in-3.15.rst:12: Unnecessary parentheses in ':func:`locale.setlocale()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/deprecations/pending-removal-in-3.15.rst:13: Unnecessary parentheses in ':func:`locale.getlocale()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/c-api/exceptions.rst:37: Unnecessary parentheses in ':func:`sys.exc_info()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/cpython/Doc/reference/datamodel.rst:383: Unnecessary parentheses in ':func:`bytes()`' (unnecessary-func-parentheses)

FAILED tests/test_xpass_friends.py::test_sphinxlint_friend_projects_shall_pass[~/repos/sphinx-lint/tests/fixtures/friends/sphinx] - ...
  + ~/repos/sphinx-lint/tests/fixtures/friends/sphinx/doc/extdev/deprecated.rst:1815: Unnecessary parentheses in ':func:`sphinx.locale._()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/sphinx/doc/extdev/deprecated.rst:1820: Unnecessary parentheses in ':func:`sphinx.locale._()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/sphinx/doc/extdev/deprecated.rst:1825: Unnecessary parentheses in ':func:`sphinx.locale._()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/sphinx/doc/usage/restructuredtext/directives.rst:843: Unnecessary parentheses in ':func:`textwrap.dedent()`' (unnecessary-func-parentheses)

FAILED tests/test_xpass_friends.py::test_sphinxlint_friend_projects_shall_pass[~/repos/sphinx-lint/tests/fixtures/friends/pandas] - ...
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.15.1.rst:266: Unnecessary parentheses in ':func:`io.wb.download()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.15.0.rst:493: Unnecessary parentheses in ':func:`rolling_*()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.15.0.rst:570: Unnecessary parentheses in ':func:`ewm*()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.15.0.rst:579: Unnecessary parentheses in ':func:`expanding_*()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:577: Unnecessary parentheses in ':func:`read_excel()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1095: Unnecessary parentheses in ':func:`read_excel()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1098: Unnecessary parentheses in ':func:`read_excel()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1210: Unnecessary parentheses in ':func:`IntervalIndex.symmetric_difference()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1329: Unnecessary parentheses in ':func:`Timedelta.total_seconds()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1433: Unnecessary parentheses in ':func:`DataFrame.to_latex()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1434: Unnecessary parentheses in ':func:`DataFrame.to_latex()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1435: Unnecessary parentheses in ':func:`DataFrame.to_latex()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1436: Unnecessary parentheses in ':func:`DataFrame.to_latex()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1437: Unnecessary parentheses in ':func:`DataFrame.to_latex()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.23.0.rst:1438: Unnecessary parentheses in ':func:`DataFrame.to_latex()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:321: Unnecessary parentheses in ':func:`DataFrame.clip()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:980: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:981: Unnecessary parentheses in ':func:`read_excel()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:982: Unnecessary parentheses in ':func:`read_excel()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:983: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:1048: Unnecessary parentheses in ':func:`read_excel()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:1157: Unnecessary parentheses in ':func:`Series.quantile()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.21.0.rst:1197: Unnecessary parentheses in ':func:`Series.clip()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v1.1.0.rst:1086: Unnecessary parentheses in ':func:`read_sas()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v1.1.0.rst:1183: Unnecessary parentheses in ':func:`eval()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:726: Unnecessary parentheses in ':func:`Period.to_timestamp()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:727: Unnecessary parentheses in ':func:`PeriodIndex.to_timestamp()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1659: Unnecessary parentheses in ':func:`to_timedelta()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1807: Unnecessary parentheses in ':func:`read_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1808: Unnecessary parentheses in ':func:`read_excel()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1809: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1810: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1811: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1812: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1813: Unnecessary parentheses in ':func:`read_sas()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1814: Unnecessary parentheses in ':func:`read_sas()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1815: Unnecessary parentheses in ':func:`read_sas()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1816: Unnecessary parentheses in ':func:`read_sas()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1818: Unnecessary parentheses in ':func:`DataFrame.to_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1819: Unnecessary parentheses in ':func:`DataFrame.to_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1820: Unnecessary parentheses in ':func:`DataFrame.to_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1821: Unnecessary parentheses in ':func:`DataFrame.to_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1822: Unnecessary parentheses in ':func:`DataFrame.to_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1823: Unnecessary parentheses in ':func:`DataFrame.to_string()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1824: Unnecessary parentheses in ':func:`DataFrame.to_string()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1828: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1829: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1830: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1831: Unnecessary parentheses in ':func:`read_csv()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1832: Unnecessary parentheses in ':func:`read_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1838: Unnecessary parentheses in ':func:`DataFrame.to_string()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.24.0.rst:1846: Unnecessary parentheses in ':func:`DataFrame.to_string()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.25.0.rst:1091: Unnecessary parentheses in ':func:`DataFrame.astype()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.25.0.rst:1149: Unnecessary parentheses in ':func:`DataFrame.to_html()`' (unnecessary-func-parentheses)
  + ~/repos/sphinx-lint/tests/fixtures/friends/pandas/doc/source/whatsnew/v0.25.0.rst:1174: Unnecessary parentheses in ':func:`DataFrame.to_excel()`' (unnecessary-func-parentheses)
======================== 4 failed, 108 passed in 21.66s ========================

```

</details> 