### PR TITLE
CI: Move friend projects to own job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v1
+      - uses: hynek/build-and-inspect-python-package@v2
 
   # Upload to Test PyPI on every commit on main.
   release-test-pypi:
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Packages
           path: dist
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Packages
           path: dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -49,7 +49,7 @@ jobs:
           tox -e py
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@ jobs:
         # friend projects below to the latest one
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        test-set: [base]
+        include:
+          - {python-version: "3.13", os: ubuntu-latest, test-set: friend-projects}
         exclude:
           # TODO Add Windows when regex wheel available for 3.13
           - {os: windows-latest, python-version: "3.13"}
@@ -42,7 +45,7 @@ jobs:
           pip install -U tox
 
       - name: Download more tests from friend projects
-        if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
+        if: matrix.test-set == 'friend-projects'
         run: sh download-more-tests.sh
       - name: Tox tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.6.2
     hooks:
       - id: ruff
         args: ["--exit-non-zero-on-fix"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -19,6 +19,16 @@ repos:
       - id: trailing-whitespace
         exclude: tests/fixtures/xfail/trailing-whitespaces.rst
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.2
+    hooks:
+      - id: check-github-workflows
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 1.7.0
     hooks:
@@ -26,7 +36,7 @@ repos:
         additional_dependencies: [tox]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.16
+    rev: v0.19
     hooks:
       - id: validate-pyproject
 


### PR DESCRIPTION
The Python 3.13/Ubuntu job on the CI also runs the tests on "friend projects", to make sure we don't unexpectedly break things for them.

In PRs like https://github.com/sphinx-contrib/sphinx-lint/pull/115, it fails because we're introducing a new rule, and this is expected.

This PR moves the friend project tests to their own job, so it's clear what the failure is.

| Before | After |
|--------|--------|
| <img width="259" alt="image" src="https://github.com/user-attachments/assets/78ff671e-33a7-4b49-836b-c3ec9a15112c"> | <img width="290" alt="image" src="https://github.com/user-attachments/assets/0f47579b-c1e3-415a-ae50-07020c784604"> |

Also bump the GitHub Actions versions, and add more GHA linting because I made a few syntax errors doing this and it's better to know about them before pushing :)