### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,7 @@ jobs:
         test-set: [base]
         include:
           - {python-version: "3.13", os: ubuntu-latest, test-set: friend-projects}
-        exclude:
-          # TODO Add Windows when regex wheel available for 3.13
-          - {os: windows-latest, python-version: "3.13"}
+          - {python-version: "3.13", os: windows-latest, test-set: friend-projects}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # when adding new versions, update the one used to test
         # friend projects below to the latest one
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         test-set: [base]
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,13 @@ authors = [
     {name = "Georg Brandl", email = "georg@python.org"},
     {name = "Julien Palard", email = "julien@palard.fr"},
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Python Software Foundation License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -5,7 +5,7 @@ In this file:
 - All compiled regexes are suffixed by _RE
 """
 
-from functools import lru_cache
+from functools import cache
 
 import regex as re
 
@@ -153,7 +153,7 @@ ASCII_ALLOWED_AFTER_INLINE_MARKUP = r"""-.,:;!?/'")\]}>"""
 UNICODE_ALLOWED_AFTER_INLINE_MARKUP = r"\p{Pe}\p{Pi}\p{Pf}\p{Pd}\p{Po}"
 
 
-@lru_cache(maxsize=None)
+@cache
 def inline_markup_gen(start_string, end_string, extra_allowed_before=""):
     """Generate a regex matching an inline markup.
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{py3, 313, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
Python 3.8 is end-of-life next week:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan

There's also now a regex wheel available for 3.13 so we can test 3.13 on Windows.