### PR TITLE
Add support for Python 3.14 and enable colour help

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         # when adding new versions, update the one used to test
-        # friend projects below to the latest one
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # friend projects below to the latest stable
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         test-set: [base]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,6 @@ jobs:
         include:
           - {python-version: "3.13", os: ubuntu-latest, test-set: friend-projects}
           - {python-version: "3.13", os: windows-latest, test-set: friend-projects}
-        exclude:
-          # Pending 3.14 wheels for regex https://pypi.org/project/regex/#files
-          - {python-version: "3.14", os: windows-latest}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
         include:
           - {python-version: "3.13", os: ubuntu-latest, test-set: friend-projects}
           - {python-version: "3.13", os: windows-latest, test-set: friend-projects}
+        exclude:
+          # Pending 3.14 wheels for regex https://pypi.org/project/regex/#files
+          - {python-version: "3.14", os: windows-latest}
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Documentation :: Sphinx",
 ]
 dynamic = [

--- a/sphinxlint/cli.py
+++ b/sphinxlint/cli.py
@@ -27,6 +27,7 @@ def parse_args(argv=None):
     if argv is None:
         argv = sys.argv
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.color = True
 
     enabled_checkers_names = {
         checker.name for checker in all_checkers.values() if checker.enabled

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{py3, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
Enable colour help for Python 3.14:

<img width="829" alt="image" src="https://github.com/user-attachments/assets/d3f224e8-d135-4bdc-812d-e4ee2365af24" />

https://docs.python.org/3.14/library/argparse.html#color