### PR TITLE
NEW: Ignore line length when line only contains a long URL

### DIFF
--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -421,6 +421,7 @@ _is_long_interpreted_text = re.compile(r"^\s*\W*(:(\w+:)+)?`.*`\W*$").match
 _starts_with_directive_or_hyperlink = re.compile(r"^\s*\.\. ").match
 _starts_with_anonymous_hyperlink = re.compile(r"^\s*__ ").match
 _is_very_long_string_literal = re.compile(r"^\s*``[^`]+``$").match
+_is_very_long_inline_link = re.compile(r"^\s*<.*(>`_).?$").match
 
 
 @checker(".rst", ".po", enabled=False, rst_only=True)
@@ -439,6 +440,8 @@ def check_line_too_long(file, lines, options=None):
                 continue  # ignore anonymous hyperlink targets
             if _is_very_long_string_literal(line):
                 continue  # ignore a very long literal string
+            if _is_very_long_inline_link(line):
+                continue  # ignore a very long URL on its own line"
             yield lno + 1, f"Line too long ({len(line) - 1}/{options.max_line_length})"
 
 

--- a/tests/fixtures/xpass/long-inline-link.rst
+++ b/tests/fixtures/xpass/long-inline-link.rst
@@ -1,0 +1,16 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus
+volutpat felis, eu egestas sapien tristique a. Vivamus scelerisque nunc nec arcu
+pharetra, sit amet feugiat lorem consequat. See this extremely long link here:
+`A Very Long Inline Link Example
+<https://www.example.com/this-link-is-unusually-long-and-contains-a-lot-of-characters-as-well-as-additional-query-params?param1=value1&param2=value2&param3=value3&more_values=true>`_.
+
+Donec ultrices, nisi sit amet cursus pharetra, arcu lacus tincidunt ligula, eget
+fringilla ex turpis vel odio. Curabitur feugiat pretium lorem a fringilla.
+Suspendisse eget orci eu sem tincidunt auctor.
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus
+    volutpat felis, eu egestas sapien tristique a. Vivamus scelerisque nunc nec
+    arcu pharetra, sit amet feugiat lorem consequat. See this extremely long
+    link here: `A Very Long Inline Link Example
+    <https://www.example.com/this-link-is-unusually-long-and-contains-a-lot-of-characters-as-well-as-additional-query-params?param1=value1&param2=value2&param3=value3&more_values=true>`_.
+


### PR DESCRIPTION
Ignores lines whose contents are some whitespace, <, any text, >`_, then an optional punctuation. This allows for long lines to be a URL without breaking then, so that they remain clickable.

For example:

```
pharetra, sit amet feugiat lorem consequat. `A Very Long Inline Link Example
<https://www.example.com/this-link-is-unusually-long-and-contains-a-lot-of-characters-as-well-as-additional-query-params?param1=value1&param2=value2&param3=value3&more_values=true>`_.
More text here...
```

xref: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#external-links