### PR TITLE
feat: add checker for role with extra backtick

### DIFF
--- a/sphinxlint/checkers.py
+++ b/sphinxlint/checkers.py
@@ -302,6 +302,19 @@ def check_role_with_double_backticks(file, lines, options=None):
 
 
 @checker(".rst", ".po")
+def check_role_with_extra_backtick(filename, lines, options):
+    """Check for extra backtick in roles.
+
+    Bad:  :func:`foo``
+    Bad:  :func:``foo`
+    Good: :func:`foo`
+    """
+    for lno, line in enumerate(lines, start=1):
+        for match in rst.ROLE_WITH_EXTRA_BACKTICK_RE.finditer(line):
+            yield lno, f"Extra backtick in role: {match.group(0).strip()!r}"
+
+
+@checker(".rst", ".po")
 def check_missing_space_before_role(file, lines, options=None):
     """Search for missing spaces before roles.
 

--- a/sphinxlint/rst.py
+++ b/sphinxlint/rst.py
@@ -249,6 +249,13 @@ THREE_DOT_DIRECTIVE_RE = re.compile(rf"\.\.\. {ALL_DIRECTIVES}::")
 # :const:`None`
 DOUBLE_BACKTICK_ROLE_RE = re.compile(rf"(?<!``){ROLE_HEAD}``")
 
+# Find roles with extra backtick like:
+# :mod:`!cgi`` (extra backtick at the end)
+# :mod:``!cgi` (extra backtick at the beginning)
+ROLE_WITH_EXTRA_BACKTICK_RE = re.compile(
+    rf"({ROLE_HEAD}(?:``[^`\s]+`(?!\S)|`[^`\s]+``))(?!`)"
+)
+
 START_STRING_PREFIX = f"(^|(?<=\\s|[{OPENERS}{DELIMITERS}|]))"
 END_STRING_SUFFIX = f"($|(?=\\s|[\x00{CLOSING_DELIMITERS}{DELIMITERS}{CLOSERS}|]))"
 

--- a/tests/fixtures/xfail/role-with-extra-backtick.rst
+++ b/tests/fixtures/xfail/role-with-extra-backtick.rst
@@ -1,0 +1,15 @@
+.. expect: Extra backtick in role: ':mod:`!cgi``' (role-with-extra-backtick)
+.. expect: Extra backtick in role: ':mod:``!cgitb`' (role-with-extra-backtick)
+.. expect: Extra backtick in role: ':func:`foo``' (role-with-extra-backtick)
+.. expect: Extra backtick in role: ':class:`MyClass``' (role-with-extra-backtick)
+.. expect: Extra backtick in role: ':meth:``method`' (role-with-extra-backtick)
+
+This file contains roles with extra backtick that should be detected.
+
+* :pep:`594`: Remove the :mod:`!cgi`` and :mod:``!cgitb` modules
+
+* :func:`foo`` should be :func:`foo`
+
+* :class:`MyClass`` is wrong
+
+* :meth:``method` should be fixed


### PR DESCRIPTION
resolve #64 

~~The only failed case of pandas doc is expected ([this GitHub search link](https://github.com/search?q=repo%3Apandas-dev%2Fpandas+%2F%5B%5E%60%5D%3A%28class%7Cmeth%29%3A%5C%60%5B%5E%5C%60%5Cs%5D*%5C%60%5C%60%2F&type=code) lists the roles with extra backtick in pandas doc).~~
~~If this PR looks legit, I'll send a PR to pandas.~~ 
updated: I've sent a [PR](https://github.com/pandas-dev/pandas/pull/61839) to pandas, and it has been merged.