### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # when adding new versions, update the one used to test
         # friend projects below to the latest stable
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         test-set: [base]
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,12 @@ authors = [
   { name = "Georg Brandl", email = "georg@python.org" },
   { name = "Julien Palard", email = "julien@palard.fr" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Natural Language :: English",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{py3, 314, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
It's almost EOL:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/
