### PR TITLE
Add zizmor security linter and fix findings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     if: |
-      github.repository_owner == 'sphinx-contrib'
+      github.event.repository.fork == false
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
   release-pypi:
     name: Publish released package to pypi.org
     if: |
-      github.repository_owner == 'sphinx-contrib'
+      github.event.repository.fork == false
       && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: build-package

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
 
 permissions: {}
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   # Always build & lint package.
   build-package:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,7 @@ on:
       - published
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   # Always build & lint package.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,11 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
-
-permissions:
-  contents: read
+  RUFF_OUTPUT_FORMAT: github
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +19,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.x"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+          persist-credentials: false
+      - uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3 # v2.0.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@ name: Tests
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,11 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.21.0
     hooks:


### PR DESCRIPTION
https://zizmor.sh/ is a very useful security scanner to help prevent supply-chain attacks via GitHub Actions.

This PR adds it to pre-commit and fixes the findings:

* Fix: warning[artipacked]: credential persistence through GitHub Actions artifacts
* Fix: warning[excessive-permissions]: overly broad permissions

Also:
* Reduce permissions in deploy.yml
* Replace pre-commit with prek to fix [Node.js 20 deprecation warning](https://github.com/sphinx-contrib/sphinx-lint/actions/runs/28323537148?pr=163)
* Add colour to deploy logs
* Disable occasional annoying pip warning
* Don't hardcode org name in `if` statement, easier to re-use in other projects